### PR TITLE
Only refresh tickers when the window is focused, prevent API usage from exceeding limits

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,9 +51,11 @@ function constructor() {
 
 // refresh the tickers
 function refresh() {
-	tickers.forEach(ticker => {
-		ticker.refresh();
-	});
+	if (vscode.window.state.focused) {
+		tickers.forEach(ticker => {
+			ticker.refresh();
+		});
+	}
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
## Current behavior

Current version of the extension keep refreshing the tickers regardless of whether the window is focused or not. When opening multiple VS Code windows or windows running in the background, it can easily exceed the API limit.

## Changes

Let the tickers refreshed only when the window is focused, reducing unused API calls.